### PR TITLE
Switch to page by id offset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ tmp
 *.lock
 *.*_old
 .vscode
+*.ipynb
+!examples/*.ipynb
+*.db
+*.db.wal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ldlite-rtr"
-version = "0.1.0"
+version = "0.1.1"
 description = "Lightweight analytics tool for Okapi-based services. Based on the original ldlite package from the Library Data Platform project: https://github.com/library-data-platform/ldlite"
 authors = [
     "Nassib Nassar <nassib@indexdata.com>",
@@ -18,6 +18,9 @@ packages = [
     { include = "ldlite", from = "src" }
 ]
 repository = "https://github.com/bltravis/ldlite"
+
+[tool.poetry.group.dev.dependencies]
+ipykernel = "^6.29.5"
 
 [project]
 name = "ldlite"
@@ -46,7 +49,7 @@ duckdb = "^1.1.3"
 psycopg2-binary = "^2.9.10"
 tqdm = "^4.67.1"
 xlsxwriter = "^3.2.0"
-folioclient = "^0.61.1"
+folioclient = "^0.61.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -385,7 +385,8 @@ class LDLite:
                 )
             try:
                 j = resp.json()
-                _query_key = list(j.keys())[0]
+                if isinstance(j, dict):
+                    _query_key = list(j.keys())[0]
             except ValueError as e:
                 raise RuntimeError("received server response: " + resp.text) from e
             if "totalRecords" in j:
@@ -424,6 +425,7 @@ class LDLite:
             cur = self.db.cursor()
             try:
                 if "sortby id" in querycopy.get("query", "").lower() and not limit:
+                    querycopy["query"] = querycopy["query"].replace("sortby id", "sortBy id")
                     print("ldlite: query sorts by id and no limit set: Using id offset paging")
                     for idx, d in enumerate(
                         self.folio_client.folio_get_all_by_id_offset(

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -423,7 +423,7 @@ class LDLite:
                     )
             cur = self.db.cursor()
             try:
-                if "sortBy id" in querycopy.get("query", "") and not limit:
+                if "sortby id" in querycopy.get("query", "").lower() and not limit:
                     print("ldlite: query sorts by id and no limit set: Using id offset paging")
                     for idx, d in enumerate(
                         self.folio_client.folio_get_all_by_id_offset(


### PR DESCRIPTION
When handling queries with no limit and `sortBy id`, use FolioClient.folio_get_all_by_id_offset to page through with id-based offset queries instead off using limit + offset query parameter paging method. This should improve performance when extracting large datasets.